### PR TITLE
Хук чтобы поставить настройки короткого описания товара вместе

### DIFF
--- a/inc/ProductsWalker.php
+++ b/inc/ProductsWalker.php
@@ -70,6 +70,8 @@ class ProductsWalker
 
     self::add_setting_wooms_batch_size();
     self::add_setting_short_description();
+
+	do_action('wooms_add_settings');
   }
 
 


### PR DESCRIPTION
## Какие проблемы решаем?

Ставим настройки из мини-плагина WooMS Excerpt после опции "Использовать краткое описание продуктов вместо полного". Без данного хука они встают ниже.

## Чек лист

- [x] Изменения протестированы локально
- [ ] В changelog добавлено описание изменений

