### PR TITLE
Удаление дубликатов wooms meta-данных у товаров созданных путем копирования

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -228,6 +228,6 @@ function wooms_id_check_if_unique($post_ID, $post = '', $update = '') {
     do_action(
         'wooms_logger',
         $type = 'WooMS-Request',
-        $title =  sprintf('Дубли meta-полей wooms для товаров и вариаций (%s) не удалены', implode(', ', $ids)),
+        $title =  sprintf('Дубли meta-полей wooms для товаров и вариаций (%s) удалены', implode(', ', $ids))
     );
 }

--- a/wooms.php
+++ b/wooms.php
@@ -129,6 +129,8 @@ class WooMS_Core
     });
 
     add_action('init', [__CLASS__, 'delete_old_schedules']);
+
+	add_action('save_post', 'wooms_id_check_if_unique', 10, 3);
   }
 
 
@@ -295,7 +297,6 @@ class WooMS_Core
       as_unschedule_all_actions('wooms_product_single_update', [], 'ProductWalker');
     }
   }
-
 }
 
 WooMS_Core::init();


### PR DESCRIPTION
## Какие проблемы решаем?

https://github.com/wpcraft-ru/wooms/issues/409

При создании товара копированием мета-данные также копируются, что при определенных условиях может вызывать зацикливание Walker-а. Плагины, такие как "Duplicate Page" и "Duplicate Page and Post" используют один и тот же кусок кода и просто копируют и пишут (SELECT и INSERT) в базу. "Yoast Duplicate Post" использует add_post_meta и даже имеет "meta blacklist", но погоды это уже не делает. Т.е. мы не можем проверить уникальность перед тем как данные попадают в базу. Эти плагины сохраняют запись в draft, у Yoast можно выбрать и даже сразу ставить publish, но вряд ли кто-то так делает, таким образом предполагаем, что после копирования есть еще хотя бы одно сохранение данных, поэтому вешаем проверку и удаление дубликатов на save_post.

Если у товара был обнаружен дублированный wooms_id, при наличии у него вариаций (нужно насширить список возможных вариантов?) удаляем все wooms-данные у вариации без проверки на уникальность. 

## Чек лист

- [x] Изменения протестированы локально
- [ ] В changelog добавлено описание изменений

