### PR TITLE
bugfix

### DIFF
--- a/includes/ProductsImage.php
+++ b/includes/ProductsImage.php
@@ -84,7 +84,7 @@ function add_settings()
         $args = [
             'key' => 'woomss_images_sync_enabled',
             'value' => checked(1, get_option('woomss_images_sync_enabled'), false),
-        ],
+        ]
     );
 
     register_setting('mss-settings', 'woomss_images_replace_to_sync');
@@ -101,7 +101,7 @@ function add_settings()
         $args = [
             'key' => 'woomss_images_replace_to_sync',
             'value' => checked(1, get_option('woomss_images_replace_to_sync'), false),
-        ],
+        ]
     );
 }
 


### PR DESCRIPTION
## Какие проблемы решаем? Что есть?

При активации плагина. php 7.2, обычный "шаред хостинг"

Fatal error: Uncaught Error: syntax error, unexpected ')'
in /wp-content/plugins/wooms-master/includes/ProductsImage.php on line 88
и ниже на 104/105

## Как надо? Как это должно работать?

Должно запускаться

## Чек лист

- [х] Изменения протестированы локально
- [ ] В changelog добавлено описание изменений

